### PR TITLE
Fixed transition from first frame to last frame during reverse animation.

### DIFF
--- a/src/ofxSpriteSheetRenderer.cpp
+++ b/src/ofxSpriteSheetRenderer.cpp
@@ -192,7 +192,7 @@ bool ofxSpriteSheetRenderer::addTile(animation_t* sprite, float x, float y, int 
 			if(gameTime > sprite->next_tick) {
 				sprite->frame += sprite->frame_skip;
 				// increment frame and keep it within range
-				if(sprite->frame < 0) sprite->frame = sprite->total_frames;
+				if(sprite->frame < 0) sprite->frame = sprite->total_frames - 1;
 				if(sprite->frame >= sprite->total_frames) sprite->frame = 0;
 				sprite->next_tick = gameTime + sprite->frame_duration;
 				// decrement loop count if cycle complete
@@ -224,7 +224,7 @@ bool ofxSpriteSheetRenderer::addRotatedTile(animation_t* sprite, float x, float 
 			if(gameTime > sprite->next_tick) {
 				sprite->frame += sprite->frame_skip;
 				// increment frame and keep it within range
-				if(sprite->frame < 0) sprite->frame = sprite->total_frames;
+				if(sprite->frame < 0) sprite->frame = sprite->total_frames - 1;
 				if(sprite->frame >= sprite->total_frames) sprite->frame = 0;
 				sprite->next_tick = gameTime + sprite->frame_duration;
 				// decrement loop count if cycle complete
@@ -256,7 +256,7 @@ bool ofxSpriteSheetRenderer::addCenteredTile(animation_t* sprite, float x, float
 			if(gameTime > sprite->next_tick) {
 				sprite->frame += sprite->frame_skip;
 				// increment frame and keep it within range
-				if(sprite->frame < 0) sprite->frame = sprite->total_frames;
+				if(sprite->frame < 0) sprite->frame = sprite->total_frames - 1;
 				if(sprite->frame >= sprite->total_frames) sprite->frame = 0;
 				sprite->next_tick = gameTime + sprite->frame_duration;
 				// decrement loop count if cycle complete
@@ -288,7 +288,7 @@ bool ofxSpriteSheetRenderer::addCenterRotatedTile(animation_t* sprite, float x, 
 			if(gameTime > sprite->next_tick) {
 				sprite->frame += sprite->frame_skip;
 				// increment frame and keep it within range
-				if(sprite->frame < 0) sprite->frame = sprite->total_frames;
+				if(sprite->frame < 0) sprite->frame = sprite->total_frames - 1;
 				if(sprite->frame >= sprite->total_frames) sprite->frame = 0;
 				sprite->next_tick = gameTime + sprite->frame_duration;
 				// decrement loop count if cycle complete


### PR DESCRIPTION
A case of the simple (but consequential) typo? With the original code, playing the animation in reverse doesn't work: the sheet gets stuck on frame 0. This is because when the frame increments to less than zero, it gets set to "total_frames." There is no such frame (should be "total_frames - 1"), but it doesn't even matter because it immediately triggers the following line, which sets the frame to 0. Next increment it gets set back to "total_frames" and then back to 0, and so on forever. Changing the first line to set the frame correctly fixes the problem.